### PR TITLE
Refactor: Service Decoupling using Eventbus

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A WhatsApp-style real-time chat application featuring video/voice calls, group m
 - **JWT** authentication with secure HTTP-only cookies
 - **Bcrypt** password hashing
 - Custom **PeerJS server** fork with pub/sub functionality
+- Uses an internal **event bus** to decouple its services
 
 ### API Design
 - **ts-rest** for type-safe API contracts between frontend and backend

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
         "@nestjs/common": "^11.1.12",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.12",
+        "@nestjs/event-emitter": "^3.1.0",
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/mongoose": "^11.0.4",
         "@nestjs/platform-express": "^11.1.12",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { RealTimeChatGateway } from './gateways/socket.gateway';
 import { MongooseModule } from '@nestjs/mongoose';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import {
     ContactGroupEntity,
     ContactGroupSchema,
@@ -99,6 +100,7 @@ import { IgnoredUserController } from './controllers/ignored-user.controller';
                 };
             },
         }),
+        EventEmitterModule.forRoot(),
     ],
     controllers: [
         AppController,
@@ -117,6 +119,7 @@ import { IgnoredUserController } from './controllers/ignored-user.controller';
         ContactService,
         ContactGroupService,
         ContactRequestService,
+        EventBusService,
         IgnoredUserService,
         MessageService,
         ObjectStorageService,

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -54,6 +54,7 @@ import {
 } from './schemas/ignored-user.schema';
 import { ContactRequestController } from './controllers/contact-request.controller';
 import { IgnoredUserController } from './controllers/ignored-user.controller';
+import { EventBusService } from './services/event-bus.service';
 
 @Module({
     imports: [

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -15,6 +15,7 @@ import { Cache } from 'cache-manager';
 import { ContactGroupEntity } from './schemas/contact-group.schema';
 import { FileAccessEntity } from './schemas/file-access.schema';
 import { ContactRequestEntity } from './schemas/contact-request.schema';
+import { IgnoredUserEntity } from './schemas/ignored-user.schema';
 
 @Injectable()
 export class AppService implements OnApplicationBootstrap {
@@ -29,6 +30,8 @@ export class AppService implements OnApplicationBootstrap {
         private readonly contactRequestModel: Model<ContactRequestEntity>,
         @InjectModel(FileAccessEntity.name)
         private readonly fileAccessModel: Model<FileAccessEntity>,
+        @InjectModel(IgnoredUserEntity.name)
+        private readonly ignoredUserModel: Model<IgnoredUserEntity>,
         @InjectModel(MessageEntity.name)
         private readonly messageModel: Model<MessageEntity>,
         @InjectModel(UserEntity.name)
@@ -37,6 +40,10 @@ export class AppService implements OnApplicationBootstrap {
 
     async onApplicationBootstrap() {
         await this.cache.clear();
+
+        this.logger.log('Deleting all user ignores...');
+        await this.ignoredUserModel.deleteMany({});
+        this.logger.log('All user ignores have been deleted.');
 
         this.logger.log('Deleting all messages...');
         await this.messageModel.deleteMany({});

--- a/backend/src/events/contact.events.ts
+++ b/backend/src/events/contact.events.ts
@@ -1,38 +1,17 @@
 import { Contact } from '../../shared/contact.contract';
 import { ContactGroup } from '../../shared/contact-group.contract';
 
-/**
- * Emitted when a contact should be auto-added (e.g., after receiving first message)
- * Listeners: ContactService
- */
 export interface ContactAutoAddEvent {
-    userId: string; // User to add contact to
-    contactUserId: string; // Contact to add
+    userId: string;
+    contactUserId: string;
 }
 
-/**
- * Emitted when a contact group should be auto-added (e.g., after receiving first group message)
- * Listeners: ContactService, RealTimeChatGateway
- */
 export interface ContactGroupAutoAddEvent {
     userId: string;
     group: ContactGroup;
 }
 
-/**
- * Emitted when a contact is added
- * Listeners: RealTimeChatGateway
- */
 export interface ContactAddedEvent {
     userId: string;
     contact: Contact;
-}
-
-/**
- * Emitted when a contact is removed
- * Listeners: RealTimeChatGateway
- */
-export interface ContactRemovedEvent {
-    userId: string;
-    contactId: string;
 }

--- a/backend/src/events/contact.events.ts
+++ b/backend/src/events/contact.events.ts
@@ -1,0 +1,38 @@
+import { Contact } from '../../shared/contact.contract';
+import { ContactGroup } from '../../shared/contact-group.contract';
+
+/**
+ * Emitted when a contact should be auto-added (e.g., after receiving first message)
+ * Listeners: ContactService
+ */
+export interface ContactAutoAddEvent {
+    userId: string; // User to add contact to
+    contactUserId: string; // Contact to add
+}
+
+/**
+ * Emitted when a contact group should be auto-added (e.g., after receiving first group message)
+ * Listeners: ContactService, RealTimeChatGateway
+ */
+export interface ContactGroupAutoAddEvent {
+    userId: string;
+    group: ContactGroup;
+}
+
+/**
+ * Emitted when a contact is added
+ * Listeners: RealTimeChatGateway
+ */
+export interface ContactAddedEvent {
+    userId: string;
+    contact: Contact;
+}
+
+/**
+ * Emitted when a contact is removed
+ * Listeners: RealTimeChatGateway
+ */
+export interface ContactRemovedEvent {
+    userId: string;
+    contactId: string;
+}

--- a/backend/src/events/event-names.enum.ts
+++ b/backend/src/events/event-names.enum.ts
@@ -1,0 +1,20 @@
+/**
+ * Event names enum for type-safe event handling
+ */
+export enum EventNames {
+    // Message events
+    MESSAGE_SENT = 'message.sent',
+    MESSAGE_READ = 'message.read',
+
+    // Contact events
+    CONTACT_AUTO_ADD = 'contact.auto-add',
+    CONTACT_ADDED = 'contact.added',
+
+    // Contact group events
+    CONTACT_GROUP_AUTO_ADD = 'contact-group.auto-add',
+
+    // User events
+    USER_IGNORED = 'user.ignored',
+    USER_UNIGNORED = 'user.unignored',
+    USER_IGNORE_REQUEST = 'user.ignore-request',
+}

--- a/backend/src/events/index.ts
+++ b/backend/src/events/index.ts
@@ -1,4 +1,0 @@
-// Re-export all event types
-export * from './message.events';
-export * from './contact.events';
-export * from './user.events';

--- a/backend/src/events/index.ts
+++ b/backend/src/events/index.ts
@@ -1,0 +1,4 @@
+// Re-export all event types
+export * from './message.events';
+export * from './contact.events';
+export * from './user.events';

--- a/backend/src/events/message.events.ts
+++ b/backend/src/events/message.events.ts
@@ -1,9 +1,5 @@
 import { Message } from '../../shared/message.contract';
 
-/**
- * Emitted when a message is successfully sent
- * Listeners: ContactService (auto-add), RealTimeChatGateway (broadcast)
- */
 export interface MessageSentEvent {
     fromUserId: string;
     toUserId: string;
@@ -12,20 +8,7 @@ export interface MessageSentEvent {
     isGroup: boolean;
 }
 
-/**
- * Emitted when a message is marked as read
- * Listeners: RealTimeChatGateway (broadcast read receipt)
- */
 export interface MessageReadEvent {
     messageId: string;
     readerUserId: string;
-}
-
-/**
- * Emitted when messages are deleted
- * Listeners: RealTimeChatGateway (broadcast deletion)
- */
-export interface MessageDeletedEvent {
-    fromUserId: string;
-    toUserId: string;
 }

--- a/backend/src/events/message.events.ts
+++ b/backend/src/events/message.events.ts
@@ -1,10 +1,8 @@
 import { Message } from '../../shared/message.contract';
 
 export interface MessageSentEvent {
-    fromUserId: string;
-    toUserId: string;
     message: Message;
-    isGroup: boolean;
+    toUserId: string;
 }
 
 export interface MessageReadEvent {

--- a/backend/src/events/message.events.ts
+++ b/backend/src/events/message.events.ts
@@ -2,7 +2,7 @@ import { Message } from '../../shared/message.contract';
 
 export interface MessageSentEvent {
     message: Message;
-    toUserId: string;
+    recipientId: string;
 }
 
 export interface MessageReadEvent {

--- a/backend/src/events/message.events.ts
+++ b/backend/src/events/message.events.ts
@@ -3,7 +3,6 @@ import { Message } from '../../shared/message.contract';
 export interface MessageSentEvent {
     fromUserId: string;
     toUserId: string;
-    messageId: string;
     message: Message;
     isGroup: boolean;
 }

--- a/backend/src/events/message.events.ts
+++ b/backend/src/events/message.events.ts
@@ -1,5 +1,4 @@
 import { Message } from '../../shared/message.contract';
-import { ContactGroup } from '../../shared/contact-group.contract';
 
 /**
  * Emitted when a message is successfully sent

--- a/backend/src/events/message.events.ts
+++ b/backend/src/events/message.events.ts
@@ -7,5 +7,5 @@ export interface MessageSentEvent {
 
 export interface MessageReadEvent {
     messageId: string;
-    readerUserId: string;
+    messageAuthorId: string;
 }

--- a/backend/src/events/message.events.ts
+++ b/backend/src/events/message.events.ts
@@ -1,0 +1,32 @@
+import { Message } from '../../shared/message.contract';
+import { ContactGroup } from '../../shared/contact-group.contract';
+
+/**
+ * Emitted when a message is successfully sent
+ * Listeners: ContactService (auto-add), RealTimeChatGateway (broadcast)
+ */
+export interface MessageSentEvent {
+    fromUserId: string;
+    toUserId: string;
+    messageId: string;
+    message: Message;
+    isGroup: boolean;
+}
+
+/**
+ * Emitted when a message is marked as read
+ * Listeners: RealTimeChatGateway (broadcast read receipt)
+ */
+export interface MessageReadEvent {
+    messageId: string;
+    readerUserId: string;
+}
+
+/**
+ * Emitted when messages are deleted
+ * Listeners: RealTimeChatGateway (broadcast deletion)
+ */
+export interface MessageDeletedEvent {
+    fromUserId: string;
+    toUserId: string;
+}

--- a/backend/src/events/user.events.ts
+++ b/backend/src/events/user.events.ts
@@ -1,5 +1,5 @@
 export interface UserIgnoredEvent {
-    userId: string; // User who did the ignoring
+    userId: string;
     ignoredUserId: string;
 }
 

--- a/backend/src/events/user.events.ts
+++ b/backend/src/events/user.events.ts
@@ -1,0 +1,33 @@
+/**
+ * Emitted when a user ignores another user
+ * Listeners: RealTimeChatGateway (broadcast), ContactService
+ */
+export interface UserIgnoredEvent {
+    userId: string; // User who did the ignoring
+    ignoredUserId: string;
+}
+
+/**
+ * Emitted when a user un-ignores another user
+ * Listeners: RealTimeChatGateway (broadcast)
+ */
+export interface UserUnignoredEvent {
+    userId: string;
+    unignoredUserId: string;
+}
+
+/**
+ * Emitted when a user comes online
+ * Listeners: OnlineStatusService, RealTimeChatGateway
+ */
+export interface UserOnlineEvent {
+    userId: string;
+}
+
+/**
+ * Emitted when a user goes offline
+ * Listeners: OnlineStatusService, RealTimeChatGateway
+ */
+export interface UserOfflineEvent {
+    userId: string;
+}

--- a/backend/src/events/user.events.ts
+++ b/backend/src/events/user.events.ts
@@ -1,33 +1,9 @@
-/**
- * Emitted when a user ignores another user
- * Listeners: RealTimeChatGateway (broadcast), ContactService
- */
 export interface UserIgnoredEvent {
     userId: string; // User who did the ignoring
     ignoredUserId: string;
 }
 
-/**
- * Emitted when a user un-ignores another user
- * Listeners: RealTimeChatGateway (broadcast)
- */
 export interface UserUnignoredEvent {
     userId: string;
     unignoredUserId: string;
-}
-
-/**
- * Emitted when a user comes online
- * Listeners: OnlineStatusService, RealTimeChatGateway
- */
-export interface UserOnlineEvent {
-    userId: string;
-}
-
-/**
- * Emitted when a user goes offline
- * Listeners: OnlineStatusService, RealTimeChatGateway
- */
-export interface UserOfflineEvent {
-    userId: string;
 }

--- a/backend/src/gateways/socket.gateway.ts
+++ b/backend/src/gateways/socket.gateway.ts
@@ -63,9 +63,7 @@ export class RealTimeChatGateway
      */
     onModuleInit(): void {
         this.processMessageEvents();
-
         this.processContactEvents();
-
         this.processIgnoreEvents();
     }
 

--- a/backend/src/gateways/socket.gateway.ts
+++ b/backend/src/gateways/socket.gateway.ts
@@ -134,7 +134,7 @@ export class RealTimeChatGateway
             'message.sent',
             (payload: MessageSentEvent) => {
                 this.logger.debug(
-                    `Broadcasting message ${payload.messageId} to ${payload.toUserId}`,
+                    `Broadcasting message ${payload.message._id.toString()} to ${payload.toUserId}`,
                 );
                 this.server
                     .to(payload.toUserId)

--- a/backend/src/gateways/socket.gateway.ts
+++ b/backend/src/gateways/socket.gateway.ts
@@ -18,11 +18,10 @@ import { WsConnectionThrottledException } from '../errors/ws/ws-connection-throt
 import { ConfigService } from '@nestjs/config';
 import { EventBusService } from '../services/event-bus.service';
 import {
-    MessageSentEvent,
-    MessageReadEvent,
-    ContactAutoAddEvent,
-    ContactGroupAutoAddEvent,
     ContactAddedEvent,
+    ContactGroupAutoAddEvent,
+    MessageReadEvent,
+    MessageSentEvent,
     UserIgnoredEvent,
     UserUnignoredEvent,
 } from '../events';
@@ -35,7 +34,7 @@ import {
     },
 })
 export class RealTimeChatGateway
-    implements OnGatewayConnection, OnGatewayDisconnect
+    implements OnGatewayConnection, OnGatewayDisconnect, OnModuleInit
 {
     private readonly JWT_SECRET: string;
 
@@ -112,7 +111,10 @@ export class RealTimeChatGateway
                 );
                 this.server
                     .to(payload.userId)
-                    .emit(SocketMessageTypes.contactGroupAutoAdded, payload.group);
+                    .emit(
+                        SocketMessageTypes.contactGroupAutoAdded,
+                        payload.group,
+                    );
             },
         );
 
@@ -125,7 +127,10 @@ export class RealTimeChatGateway
                 );
                 this.server
                     .to(payload.userId)
-                    .emit(SocketMessageTypes.userIgnored, payload.ignoredUserId);
+                    .emit(
+                        SocketMessageTypes.userIgnored,
+                        payload.ignoredUserId,
+                    );
             },
         );
 
@@ -138,7 +143,10 @@ export class RealTimeChatGateway
                 );
                 this.server
                     .to(payload.userId)
-                    .emit(SocketMessageTypes.userUnignored, payload.unignoredUserId);
+                    .emit(
+                        SocketMessageTypes.userUnignored,
+                        payload.unignoredUserId,
+                    );
             },
         );
     }

--- a/backend/src/gateways/socket.gateway.ts
+++ b/backend/src/gateways/socket.gateway.ts
@@ -147,10 +147,10 @@ export class RealTimeChatGateway
             EventNames.MESSAGE_READ,
             (payload: MessageReadEvent) => {
                 this.logger.debug(
-                    `Broadcasting message read ${payload.messageId} to ${payload.readerUserId}`,
+                    `Broadcasting message read ${payload.messageId} to ${payload.messageAuthorId}`,
                 );
                 this.server
-                    .to(payload.readerUserId)
+                    .to(payload.messageAuthorId)
                     .emit(SocketMessageTypes.messageRead, payload.messageId);
             },
         );

--- a/backend/src/gateways/socket.gateway.ts
+++ b/backend/src/gateways/socket.gateway.ts
@@ -23,6 +23,7 @@ import {
     ContactGroupAutoAddEvent,
 } from '../events/contact.events';
 import { MessageReadEvent, MessageSentEvent } from '../events/message.events';
+import { EventNames } from '../events/event-names.enum';
 
 @WebSocketGateway({
     cors: {
@@ -70,7 +71,7 @@ export class RealTimeChatGateway
 
     private processIgnoreEvents() {
         this.eventBus.on<UserIgnoredEvent>(
-            'user.ignored',
+            EventNames.USER_IGNORED,
             (payload: UserIgnoredEvent) => {
                 this.logger.debug(
                     `Broadcasting user ignored: ${payload.ignoredUserId} by ${payload.userId}`,
@@ -85,7 +86,7 @@ export class RealTimeChatGateway
         );
 
         this.eventBus.on<UserUnignoredEvent>(
-            'user.unignored',
+            EventNames.USER_UNIGNORED,
             (payload: UserUnignoredEvent) => {
                 this.logger.debug(
                     `Broadcasting user unignored: ${payload.unignoredUserId} by ${payload.userId}`,
@@ -102,7 +103,7 @@ export class RealTimeChatGateway
 
     private processContactEvents() {
         this.eventBus.on<ContactAddedEvent>(
-            'contact.added',
+            EventNames.CONTACT_ADDED,
             (payload: ContactAddedEvent) => {
                 this.logger.debug(
                     `Broadcasting contact added ${payload.contact._id} for user ${payload.userId}`,
@@ -114,7 +115,7 @@ export class RealTimeChatGateway
         );
 
         this.eventBus.on<ContactGroupAutoAddEvent>(
-            'contact-group.auto-add',
+            EventNames.CONTACT_GROUP_AUTO_ADD,
             (payload: ContactGroupAutoAddEvent) => {
                 this.logger.debug(
                     `Auto-adding group ${payload.group._id} for user ${payload.userId}`,
@@ -131,7 +132,7 @@ export class RealTimeChatGateway
 
     private processMessageEvents() {
         this.eventBus.on<MessageSentEvent>(
-            'message.sent',
+            EventNames.MESSAGE_SENT,
             (payload: MessageSentEvent) => {
                 this.logger.debug(
                     `Broadcasting message ${payload.message._id.toString()} to ${payload.recipientId}`,
@@ -143,7 +144,7 @@ export class RealTimeChatGateway
         );
 
         this.eventBus.on<MessageReadEvent>(
-            'message.read',
+            EventNames.MESSAGE_READ,
             (payload: MessageReadEvent) => {
                 this.logger.debug(
                     `Broadcasting message read ${payload.messageId} to ${payload.readerUserId}`,

--- a/backend/src/gateways/socket.gateway.ts
+++ b/backend/src/gateways/socket.gateway.ts
@@ -17,14 +17,12 @@ import { WsConnectionThrottlerService } from '../services/ws-connection-throttle
 import { WsConnectionThrottledException } from '../errors/ws/ws-connection-throttled.exception';
 import { ConfigService } from '@nestjs/config';
 import { EventBusService } from '../services/event-bus.service';
+import { UserIgnoredEvent, UserUnignoredEvent } from '../events/user.events';
 import {
     ContactAddedEvent,
     ContactGroupAutoAddEvent,
-    MessageReadEvent,
-    MessageSentEvent,
-    UserIgnoredEvent,
-    UserUnignoredEvent,
-} from '../events';
+} from '../events/contact.events';
+import { MessageReadEvent, MessageSentEvent } from '../events/message.events';
 
 @WebSocketGateway({
     cors: {

--- a/backend/src/gateways/socket.gateway.ts
+++ b/backend/src/gateways/socket.gateway.ts
@@ -63,62 +63,14 @@ export class RealTimeChatGateway
      * Set up event listeners after module initialization
      */
     onModuleInit(): void {
-        // Listen for message.sent events and broadcast via WebSocket
-        this.eventBus.on<MessageSentEvent>(
-            'message.sent',
-            (payload: MessageSentEvent) => {
-                this.logger.debug(
-                    `Broadcasting message ${payload.messageId} to ${payload.toUserId}`,
-                );
-                this.server
-                    .to(payload.toUserId)
-                    .emit(SocketMessageTypes.message, payload.message);
-            },
-        );
+        this.processMessageEvents();
 
-        // Listen for message.read events and broadcast via WebSocket
-        this.eventBus.on<MessageReadEvent>(
-            'message.read',
-            (payload: MessageReadEvent) => {
-                this.logger.debug(
-                    `Broadcasting message read ${payload.messageId} to ${payload.readerUserId}`,
-                );
-                this.server
-                    .to(payload.readerUserId)
-                    .emit(SocketMessageTypes.messageRead, payload.messageId);
-            },
-        );
+        this.processContactEvents();
 
-        // Listen for contact.added events and broadcast via WebSocket
-        this.eventBus.on<ContactAddedEvent>(
-            'contact.added',
-            (payload: ContactAddedEvent) => {
-                this.logger.debug(
-                    `Broadcasting contact added ${payload.contact._id} for user ${payload.userId}`,
-                );
-                this.server
-                    .to(payload.userId)
-                    .emit(SocketMessageTypes.contactAutoAdded, payload.contact);
-            },
-        );
+        this.processIgnoreEvents();
+    }
 
-        // Listen for contact-group.auto-add events and broadcast via WebSocket
-        this.eventBus.on<ContactGroupAutoAddEvent>(
-            'contact-group.auto-add',
-            (payload: ContactGroupAutoAddEvent) => {
-                this.logger.debug(
-                    `Auto-adding group ${payload.group._id} for user ${payload.userId}`,
-                );
-                this.server
-                    .to(payload.userId)
-                    .emit(
-                        SocketMessageTypes.contactGroupAutoAdded,
-                        payload.group,
-                    );
-            },
-        );
-
-        // Listen for user.ignored events and broadcast via WebSocket
+    private processIgnoreEvents() {
         this.eventBus.on<UserIgnoredEvent>(
             'user.ignored',
             (payload: UserIgnoredEvent) => {
@@ -134,7 +86,6 @@ export class RealTimeChatGateway
             },
         );
 
-        // Listen for user.unignored events and broadcast via WebSocket
         this.eventBus.on<UserUnignoredEvent>(
             'user.unignored',
             (payload: UserUnignoredEvent) => {
@@ -147,6 +98,61 @@ export class RealTimeChatGateway
                         SocketMessageTypes.userUnignored,
                         payload.unignoredUserId,
                     );
+            },
+        );
+    }
+
+    private processContactEvents() {
+        this.eventBus.on<ContactAddedEvent>(
+            'contact.added',
+            (payload: ContactAddedEvent) => {
+                this.logger.debug(
+                    `Broadcasting contact added ${payload.contact._id} for user ${payload.userId}`,
+                );
+                this.server
+                    .to(payload.userId)
+                    .emit(SocketMessageTypes.contactAutoAdded, payload.contact);
+            },
+        );
+
+        this.eventBus.on<ContactGroupAutoAddEvent>(
+            'contact-group.auto-add',
+            (payload: ContactGroupAutoAddEvent) => {
+                this.logger.debug(
+                    `Auto-adding group ${payload.group._id} for user ${payload.userId}`,
+                );
+                this.server
+                    .to(payload.userId)
+                    .emit(
+                        SocketMessageTypes.contactGroupAutoAdded,
+                        payload.group,
+                    );
+            },
+        );
+    }
+
+    private processMessageEvents() {
+        this.eventBus.on<MessageSentEvent>(
+            'message.sent',
+            (payload: MessageSentEvent) => {
+                this.logger.debug(
+                    `Broadcasting message ${payload.messageId} to ${payload.toUserId}`,
+                );
+                this.server
+                    .to(payload.toUserId)
+                    .emit(SocketMessageTypes.message, payload.message);
+            },
+        );
+
+        this.eventBus.on<MessageReadEvent>(
+            'message.read',
+            (payload: MessageReadEvent) => {
+                this.logger.debug(
+                    `Broadcasting message read ${payload.messageId} to ${payload.readerUserId}`,
+                );
+                this.server
+                    .to(payload.readerUserId)
+                    .emit(SocketMessageTypes.messageRead, payload.messageId);
             },
         );
     }

--- a/backend/src/gateways/socket.gateway.ts
+++ b/backend/src/gateways/socket.gateway.ts
@@ -134,10 +134,10 @@ export class RealTimeChatGateway
             'message.sent',
             (payload: MessageSentEvent) => {
                 this.logger.debug(
-                    `Broadcasting message ${payload.message._id.toString()} to ${payload.toUserId}`,
+                    `Broadcasting message ${payload.message._id.toString()} to ${payload.recipientId}`,
                 );
                 this.server
-                    .to(payload.toUserId)
+                    .to(payload.recipientId)
                     .emit(SocketMessageTypes.message, payload.message);
             },
         );

--- a/backend/src/gateways/socket.gateway.ts
+++ b/backend/src/gateways/socket.gateway.ts
@@ -5,7 +5,7 @@ import {
     WebSocketGateway,
     WebSocketServer,
 } from '@nestjs/websockets';
-import { Logger } from '@nestjs/common';
+import { Logger, OnModuleInit } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
 import { parse as parseCookie } from 'cookie';
 import { ContactService } from '../services/contact.service';
@@ -16,6 +16,16 @@ import { SocketMessageTypes } from '../../shared/socket-message-types.enum';
 import { WsConnectionThrottlerService } from '../services/ws-connection-throttler.service';
 import { WsConnectionThrottledException } from '../errors/ws/ws-connection-throttled.exception';
 import { ConfigService } from '@nestjs/config';
+import { EventBusService } from '../services/event-bus.service';
+import {
+    MessageSentEvent,
+    MessageReadEvent,
+    ContactAutoAddEvent,
+    ContactGroupAutoAddEvent,
+    ContactAddedEvent,
+    UserIgnoredEvent,
+    UserUnignoredEvent,
+} from '../events';
 
 @WebSocketGateway({
     cors: {
@@ -40,6 +50,7 @@ export class RealTimeChatGateway
         private readonly jwtService: JwtService,
         private readonly onlineStatusService: OnlineStatusService,
         private readonly wsThrottler: WsConnectionThrottlerService,
+        private readonly eventBus: EventBusService,
     ) {
         const jwtSecret = this.configService.get('JWT_SECRET');
         if (!jwtSecret) {
@@ -47,6 +58,89 @@ export class RealTimeChatGateway
         }
 
         this.JWT_SECRET = jwtSecret;
+    }
+
+    /**
+     * Set up event listeners after module initialization
+     */
+    onModuleInit(): void {
+        // Listen for message.sent events and broadcast via WebSocket
+        this.eventBus.on<MessageSentEvent>(
+            'message.sent',
+            (payload: MessageSentEvent) => {
+                this.logger.debug(
+                    `Broadcasting message ${payload.messageId} to ${payload.toUserId}`,
+                );
+                this.server
+                    .to(payload.toUserId)
+                    .emit(SocketMessageTypes.message, payload.message);
+            },
+        );
+
+        // Listen for message.read events and broadcast via WebSocket
+        this.eventBus.on<MessageReadEvent>(
+            'message.read',
+            (payload: MessageReadEvent) => {
+                this.logger.debug(
+                    `Broadcasting message read ${payload.messageId} to ${payload.readerUserId}`,
+                );
+                this.server
+                    .to(payload.readerUserId)
+                    .emit(SocketMessageTypes.messageRead, payload.messageId);
+            },
+        );
+
+        // Listen for contact.added events and broadcast via WebSocket
+        this.eventBus.on<ContactAddedEvent>(
+            'contact.added',
+            (payload: ContactAddedEvent) => {
+                this.logger.debug(
+                    `Broadcasting contact added ${payload.contact._id} for user ${payload.userId}`,
+                );
+                this.server
+                    .to(payload.userId)
+                    .emit(SocketMessageTypes.contactAutoAdded, payload.contact);
+            },
+        );
+
+        // Listen for contact-group.auto-add events and broadcast via WebSocket
+        this.eventBus.on<ContactGroupAutoAddEvent>(
+            'contact-group.auto-add',
+            (payload: ContactGroupAutoAddEvent) => {
+                this.logger.debug(
+                    `Auto-adding group ${payload.group._id} for user ${payload.userId}`,
+                );
+                this.server
+                    .to(payload.userId)
+                    .emit(SocketMessageTypes.contactGroupAutoAdded, payload.group);
+            },
+        );
+
+        // Listen for user.ignored events and broadcast via WebSocket
+        this.eventBus.on<UserIgnoredEvent>(
+            'user.ignored',
+            (payload: UserIgnoredEvent) => {
+                this.logger.debug(
+                    `Broadcasting user ignored: ${payload.ignoredUserId} by ${payload.userId}`,
+                );
+                this.server
+                    .to(payload.userId)
+                    .emit(SocketMessageTypes.userIgnored, payload.ignoredUserId);
+            },
+        );
+
+        // Listen for user.unignored events and broadcast via WebSocket
+        this.eventBus.on<UserUnignoredEvent>(
+            'user.unignored',
+            (payload: UserUnignoredEvent) => {
+                this.logger.debug(
+                    `Broadcasting user unignored: ${payload.unignoredUserId} by ${payload.userId}`,
+                );
+                this.server
+                    .to(payload.userId)
+                    .emit(SocketMessageTypes.userUnignored, payload.unignoredUserId);
+            },
+        );
     }
 
     async handleConnection(socket: Socket): Promise<void> {

--- a/backend/src/services/contact-request.service.ts
+++ b/backend/src/services/contact-request.service.ts
@@ -8,7 +8,7 @@ import { UserNotFoundException } from '../errors/internal/user-not-found.excepti
 import { ObjectNotFoundException } from '../errors/internal/object-not-found.exception';
 import { ContactNotFoundException } from '../errors/internal/contact-not-found.exception';
 import { EventBusService } from './event-bus.service';
-import { UserIgnoredEvent } from '../events/user.events';
+import { UserIgnoredEvent } from '../events';
 
 @Injectable()
 export class ContactRequestService {

--- a/backend/src/services/contact-request.service.ts
+++ b/backend/src/services/contact-request.service.ts
@@ -97,7 +97,6 @@ export class ContactRequestService {
             throw new ObjectNotFoundException();
         }
 
-        // Emit event for IgnoredUserService to handle
         this.eventBus.emitAsync<UserIgnoredEvent>('user.ignore-request', {
             userId,
             ignoredUserId: contactRequest.initiatorId,

--- a/backend/src/services/contact-request.service.ts
+++ b/backend/src/services/contact-request.service.ts
@@ -7,16 +7,17 @@ import { UserEntity } from '../schemas/user.schema';
 import { UserNotFoundException } from '../errors/internal/user-not-found.exception';
 import { ObjectNotFoundException } from '../errors/internal/object-not-found.exception';
 import { ContactNotFoundException } from '../errors/internal/contact-not-found.exception';
-import { IgnoredUserService } from './ignored-user.service';
+import { EventBusService } from './event-bus.service';
+import { UserIgnoredEvent } from '../events/user.events';
 
 @Injectable()
 export class ContactRequestService {
     constructor(
         @InjectModel(ContactRequestEntity.name)
         private readonly contactRequestModel: Model<ContactRequestEntity>,
-        private readonly ignoredUserService: IgnoredUserService,
         @InjectModel(UserEntity.name)
         private readonly userModel: Model<UserEntity>,
+        private readonly eventBus: EventBusService,
     ) {}
 
     public async getContactRequestByInitiatorAndTargetUserIds(
@@ -96,10 +97,11 @@ export class ContactRequestService {
             throw new ObjectNotFoundException();
         }
 
-        await this.ignoredUserService.ignoreUser(
+        // Emit event for IgnoredUserService to handle
+        this.eventBus.emitAsync<UserIgnoredEvent>('user.ignore-request', {
             userId,
-            contactRequest.initiatorId,
-        );
+            ignoredUserId: contactRequest.initiatorId,
+        });
 
         await contactRequest.deleteOne();
     }

--- a/backend/src/services/contact-request.service.ts
+++ b/backend/src/services/contact-request.service.ts
@@ -9,6 +9,7 @@ import { ObjectNotFoundException } from '../errors/internal/object-not-found.exc
 import { ContactNotFoundException } from '../errors/internal/contact-not-found.exception';
 import { EventBusService } from './event-bus.service';
 import { UserIgnoredEvent } from '../events/user.events';
+import { EventNames } from '../events/event-names.enum';
 
 @Injectable()
 export class ContactRequestService {
@@ -97,10 +98,13 @@ export class ContactRequestService {
             throw new ObjectNotFoundException();
         }
 
-        this.eventBus.emitAsync<UserIgnoredEvent>('user.ignore-request', {
-            userId,
-            ignoredUserId: contactRequest.initiatorId,
-        });
+        this.eventBus.emitAsync<UserIgnoredEvent>(
+            EventNames.USER_IGNORE_REQUEST,
+            {
+                userId,
+                ignoredUserId: contactRequest.initiatorId,
+            },
+        );
 
         await contactRequest.deleteOne();
     }

--- a/backend/src/services/contact-request.service.ts
+++ b/backend/src/services/contact-request.service.ts
@@ -8,7 +8,7 @@ import { UserNotFoundException } from '../errors/internal/user-not-found.excepti
 import { ObjectNotFoundException } from '../errors/internal/object-not-found.exception';
 import { ContactNotFoundException } from '../errors/internal/contact-not-found.exception';
 import { EventBusService } from './event-bus.service';
-import { UserIgnoredEvent } from '../events';
+import { UserIgnoredEvent } from '../events/user.events';
 
 @Injectable()
 export class ContactRequestService {

--- a/backend/src/services/contact.service.ts
+++ b/backend/src/services/contact.service.ts
@@ -11,10 +11,8 @@ import { ContactRequestEntity } from '../schemas/contact-request.schema';
 import { IgnoredUserService } from './ignored-user.service';
 import { UserIsIgnoredException } from '../errors/external/user-is-ignored.exception';
 import { EventBusService } from './event-bus.service';
-import {
-    ContactAutoAddEvent,
-    ContactAddedEvent,
-} from '../events';
+import { EventNames } from '../events/event-names.enum';
+import { ContactAddedEvent, ContactAutoAddEvent } from '../events';
 
 @Injectable()
 export class ContactService implements OnModuleInit {
@@ -30,9 +28,12 @@ export class ContactService implements OnModuleInit {
     ) {}
 
     onModuleInit(): void {
-        // Listen for contact.auto-add events from MessageService
+        this.listenOnEvents();
+    }
+
+    private listenOnEvents() {
         this.eventBus.on<ContactAutoAddEvent>(
-            'contact.auto-add',
+            EventNames.CONTACT_AUTO_ADD,
             async (payload: ContactAutoAddEvent) => {
                 this.logger.debug(
                     `Handling auto-add contact: user=${payload.userId}, contact=${payload.contactUserId}`,
@@ -44,7 +45,7 @@ export class ContactService implements OnModuleInit {
                     );
                     if (contact) {
                         this.eventBus.emitAsync<ContactAddedEvent>(
-                            'contact.added',
+                            EventNames.CONTACT_ADDED,
                             {
                                 userId: payload.userId,
                                 contact,

--- a/backend/src/services/contact.service.ts
+++ b/backend/src/services/contact.service.ts
@@ -14,7 +14,6 @@ import { EventBusService } from './event-bus.service';
 import {
     ContactAutoAddEvent,
     ContactAddedEvent,
-    ContactGroupAutoAddEvent,
 } from '../events';
 
 @Injectable()
@@ -57,18 +56,6 @@ export class ContactService implements OnModuleInit {
                         `Failed to handle contact.auto-add event: ${error}`,
                     );
                 }
-            },
-        );
-
-        // Listen for contact-group.auto-add events from MessageService
-        this.eventBus.on<ContactGroupAutoAddEvent>(
-            'contact-group.auto-add',
-            (payload: ContactGroupAutoAddEvent) => {
-                this.logger.debug(
-                    `Handling auto-add group: user=${payload.userId}, group=${payload.group._id}`,
-                );
-                // The group is already personalized for the user in the event payload
-                // Just re-emit it for any additional processing if needed
             },
         );
     }

--- a/backend/src/services/contact.service.ts
+++ b/backend/src/services/contact.service.ts
@@ -12,7 +12,10 @@ import { IgnoredUserService } from './ignored-user.service';
 import { UserIsIgnoredException } from '../errors/external/user-is-ignored.exception';
 import { EventBusService } from './event-bus.service';
 import { EventNames } from '../events/event-names.enum';
-import { ContactAddedEvent, ContactAutoAddEvent } from '../events';
+import {
+    ContactAddedEvent,
+    ContactAutoAddEvent,
+} from '../events/contact.events';
 
 @Injectable()
 export class ContactService implements OnModuleInit {

--- a/backend/src/services/contact.service.ts
+++ b/backend/src/services/contact.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { Contact } from '../../shared/contact.contract';
 import { InjectModel } from '@nestjs/mongoose';
 import { UserEntity } from '../schemas/user.schema';
@@ -10,9 +10,15 @@ import { ContactAlreadyExistsException } from '../errors/internal/contact-alread
 import { ContactRequestEntity } from '../schemas/contact-request.schema';
 import { IgnoredUserService } from './ignored-user.service';
 import { UserIsIgnoredException } from '../errors/external/user-is-ignored.exception';
+import { EventBusService } from './event-bus.service';
+import {
+    ContactAutoAddEvent,
+    ContactAddedEvent,
+    ContactGroupAutoAddEvent,
+} from '../events';
 
 @Injectable()
-export class ContactService {
+export class ContactService implements OnModuleInit {
     private readonly logger = new Logger(ContactService.name);
 
     constructor(
@@ -21,7 +27,51 @@ export class ContactService {
         private readonly onlineStatusService: OnlineStatusService,
         @InjectModel(UserEntity.name) private userModel: Model<UserEntity>,
         private readonly ignoredUserService: IgnoredUserService,
+        private readonly eventBus: EventBusService,
     ) {}
+
+    onModuleInit(): void {
+        // Listen for contact.auto-add events from MessageService
+        this.eventBus.on<ContactAutoAddEvent>(
+            'contact.auto-add',
+            async (payload: ContactAutoAddEvent) => {
+                this.logger.debug(
+                    `Handling auto-add contact: user=${payload.userId}, contact=${payload.contactUserId}`,
+                );
+                try {
+                    const contact = await this.addContactIfNotExists(
+                        payload.userId,
+                        payload.contactUserId,
+                    );
+                    if (contact) {
+                        this.eventBus.emitAsync<ContactAddedEvent>(
+                            'contact.added',
+                            {
+                                userId: payload.userId,
+                                contact,
+                            },
+                        );
+                    }
+                } catch (error) {
+                    this.logger.error(
+                        `Failed to handle contact.auto-add event: ${error}`,
+                    );
+                }
+            },
+        );
+
+        // Listen for contact-group.auto-add events from MessageService
+        this.eventBus.on<ContactGroupAutoAddEvent>(
+            'contact-group.auto-add',
+            (payload: ContactGroupAutoAddEvent) => {
+                this.logger.debug(
+                    `Handling auto-add group: user=${payload.userId}, group=${payload.group._id}`,
+                );
+                // The group is already personalized for the user in the event payload
+                // Just re-emit it for any additional processing if needed
+            },
+        );
+    }
 
     async getUserContacts(userId: string) {
         const user = await this.userModel.findOne({

--- a/backend/src/services/event-bus.service.ts
+++ b/backend/src/services/event-bus.service.ts
@@ -1,0 +1,100 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+/**
+ * EventBusService - Wrapper around NestJS EventEmitter2
+ * Provides a centralized way to emit and listen to domain events
+ */
+@Injectable()
+export class EventBusService {
+    private readonly logger = new Logger(EventBusService.name);
+
+    constructor(private readonly eventEmitter: EventEmitter2) {}
+
+    /**
+     * Emit an event asynchronously
+     * @param eventName - Name of the event (e.g., 'message.sent')
+     * @param payload - Event payload data
+     */
+    emitAsync<T>(eventName: string, payload: T): void {
+        this.eventEmitter.emitAsync(eventName, payload);
+    }
+
+    /**
+     * Emit an event synchronously (use sparingly)
+     * @param eventName - Name of the event
+     * @param payload - Event payload data
+     */
+    emit<T>(eventName: string, payload: T): void {
+        this.eventEmitter.emit(eventName, payload);
+    }
+
+    /**
+     * Listen for an event
+     * @param eventName - Name of the event to listen for
+     * @param listener - Callback function when event is emitted
+     */
+    on<T>(eventName: string, listener: (payload: T) => void): void {
+        this.eventEmitter.on(eventName, listener);
+        this.logger.debug(`Registered listener for event: ${eventName}`);
+    }
+
+    /**
+     * Listen for an event once (auto-remove after first emission)
+     * @param eventName - Name of the event
+     * @param listener - Callback function
+     */
+    once<T>(eventName: string, listener: (payload: T) => void): void {
+        this.eventEmitter.once(eventName, listener);
+    }
+
+    /**
+     * Remove a specific listener
+     * @param eventName - Name of the event
+     * @param listener - The listener function to remove
+     */
+    off<T>(eventName: string, listener: (payload: T) => void): void {
+        this.eventEmitter.off(eventName, listener);
+    }
+
+    /**
+     * Remove all listeners for an event
+     * @param eventName - Name of the event
+     */
+    removeAllListeners(eventName: string): void {
+        this.eventEmitter.removeAllListeners(eventName);
+    }
+
+    /**
+     * Wait for an event to be emitted
+     * @param eventName - Name of the event
+     * @param timeoutMs - Optional timeout in milliseconds
+     * @returns Promise that resolves with the event payload
+     */
+    waitFor<T>(eventName: string, timeoutMs?: number): Promise<T> {
+        return new Promise((resolve, reject) => {
+            const listener = (payload: T) => {
+                this.off(eventName, listener);
+                resolve(payload);
+            };
+
+            this.on(eventName, listener);
+
+            if (timeoutMs) {
+                setTimeout(() => {
+                    this.off(eventName, listener);
+                    reject(new Error(`Timeout waiting for event: ${eventName}`));
+                }, timeoutMs);
+            }
+        });
+    }
+
+    /**
+     * Check if there are listeners for an event
+     * @param eventName - Name of the event
+     * @returns Number of listeners
+     */
+    listenerCount(eventName: string): number {
+        return this.eventEmitter.listenerCount(eventName);
+    }
+}

--- a/backend/src/services/event-bus.service.ts
+++ b/backend/src/services/event-bus.service.ts
@@ -83,7 +83,9 @@ export class EventBusService {
             if (timeoutMs) {
                 setTimeout(() => {
                     this.off(eventName, listener);
-                    reject(new Error(`Timeout waiting for event: ${eventName}`));
+                    reject(
+                        new Error(`Timeout waiting for event: ${eventName}`),
+                    );
                 }, timeoutMs);
             }
         });

--- a/backend/src/services/event-bus.service.ts
+++ b/backend/src/services/event-bus.service.ts
@@ -17,7 +17,7 @@ export class EventBusService {
      * @param payload - Event payload data
      */
     emitAsync<T>(eventName: string, payload: T): void {
-        this.eventEmitter.emitAsync(eventName, payload);
+        void this.eventEmitter.emitAsync(eventName, payload);
     }
 
     /**

--- a/backend/src/services/ignored-user.service.ts
+++ b/backend/src/services/ignored-user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { HydratedDocument, Model } from 'mongoose';
 import { IgnoredUserEntity } from '../schemas/ignored-user.schema';
@@ -23,7 +23,7 @@ export interface PaginatedResult<T> {
 }
 
 @Injectable()
-export class IgnoredUserService {
+export class IgnoredUserService implements OnModuleInit {
     private readonly logger = new Logger(IgnoredUserService.name);
 
     constructor(
@@ -33,6 +33,25 @@ export class IgnoredUserService {
         private readonly userModel: Model<UserEntity>,
         private readonly eventBus: EventBusService,
     ) {}
+
+    onModuleInit(): void {
+        // Listen for ignore requests from ContactRequestService
+        this.eventBus.on<UserIgnoredEvent>(
+            'user.ignore-request',
+            async (payload: UserIgnoredEvent) => {
+                this.logger.debug(
+                    `Handling ignore request: ${payload.userId} -> ${payload.ignoredUserId}`,
+                );
+                try {
+                    await this.ignoreUser(payload.userId, payload.ignoredUserId);
+                } catch (error) {
+                    this.logger.error(
+                        `Failed to handle ignore request: ${error}`,
+                    );
+                }
+            },
+        );
+    }
 
     /**
      * Add a user to the ignore list

--- a/backend/src/services/ignored-user.service.ts
+++ b/backend/src/services/ignored-user.service.ts
@@ -9,7 +9,7 @@ import { AlreadyIgnoredException } from '../errors/external/already-ignored.exce
 import { UserNotIgnoredException } from '../errors/external/user-not-ignored.exception';
 import { EventBusService } from './event-bus.service';
 import { EventNames } from '../events/event-names.enum';
-import { UserIgnoredEvent, UserUnignoredEvent } from '../events';
+import { UserIgnoredEvent, UserUnignoredEvent } from '../events/user.events';
 
 export interface PaginationParams {
     page?: number;

--- a/backend/src/services/ignored-user.service.ts
+++ b/backend/src/services/ignored-user.service.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { HydratedDocument, Model } from 'mongoose';
 import { IgnoredUserEntity } from '../schemas/ignored-user.schema';
@@ -7,8 +7,8 @@ import { UserNotFoundException } from '../errors/internal/user-not-found.excepti
 import { CannotIgnoreSelfException } from '../errors/external/cannot-ignore-self.exception';
 import { AlreadyIgnoredException } from '../errors/external/already-ignored.exception';
 import { UserNotIgnoredException } from '../errors/external/user-not-ignored.exception';
-import { RealTimeChatGateway } from '../gateways/socket.gateway';
-import { SocketMessageTypes } from '../../shared/socket-message-types.enum';
+import { EventBusService } from './event-bus.service';
+import { UserIgnoredEvent, UserUnignoredEvent } from '../events/user.events';
 
 export interface PaginationParams {
     page?: number;
@@ -31,8 +31,7 @@ export class IgnoredUserService {
         private readonly ignoredUserModel: Model<IgnoredUserEntity>,
         @InjectModel(UserEntity.name)
         private readonly userModel: Model<UserEntity>,
-        @Inject(forwardRef(() => RealTimeChatGateway))
-        private readonly gateway: RealTimeChatGateway,
+        private readonly eventBus: EventBusService,
     ) {}
 
     /**
@@ -87,10 +86,11 @@ export class IgnoredUserService {
 
         await this.removeContactFromUserEntity(user, ignoredUserId);
 
-        // Emit WebSocket event to the user who ignored
-        this.gateway
-            .prepareSendMessage(userId)
-            ?.emit(SocketMessageTypes.userIgnored, ignoredUserId);
+        // Emit event for WebSocket broadcast
+        this.eventBus.emitAsync<UserIgnoredEvent>('user.ignored', {
+            userId,
+            ignoredUserId,
+        });
 
         this.logger.log(`User ${userId} ignored user ${ignoredUserId}`);
     }
@@ -125,10 +125,11 @@ export class IgnoredUserService {
             throw new UserNotIgnoredException();
         }
 
-        // Emit WebSocket event to the user who un-ignored
-        this.gateway
-            .prepareSendMessage(userId)
-            ?.emit(SocketMessageTypes.userUnignored, ignoredUserId);
+        // Emit event for WebSocket broadcast
+        this.eventBus.emitAsync<UserUnignoredEvent>('user.unignored', {
+            userId,
+            unignoredUserId: ignoredUserId,
+        });
 
         this.logger.log(`User ${userId} un-ignored user ${ignoredUserId}`);
     }

--- a/backend/src/services/ignored-user.service.ts
+++ b/backend/src/services/ignored-user.service.ts
@@ -8,7 +8,7 @@ import { CannotIgnoreSelfException } from '../errors/external/cannot-ignore-self
 import { AlreadyIgnoredException } from '../errors/external/already-ignored.exception';
 import { UserNotIgnoredException } from '../errors/external/user-not-ignored.exception';
 import { EventBusService } from './event-bus.service';
-import { UserIgnoredEvent, UserUnignoredEvent } from '../events/user.events';
+import { UserIgnoredEvent, UserUnignoredEvent } from '../events';
 
 export interface PaginationParams {
     page?: number;
@@ -43,7 +43,10 @@ export class IgnoredUserService implements OnModuleInit {
                     `Handling ignore request: ${payload.userId} -> ${payload.ignoredUserId}`,
                 );
                 try {
-                    await this.ignoreUser(payload.userId, payload.ignoredUserId);
+                    await this.ignoreUser(
+                        payload.userId,
+                        payload.ignoredUserId,
+                    );
                 } catch (error) {
                     this.logger.error(
                         `Failed to handle ignore request: ${error}`,

--- a/backend/src/services/ignored-user.service.ts
+++ b/backend/src/services/ignored-user.service.ts
@@ -8,6 +8,7 @@ import { CannotIgnoreSelfException } from '../errors/external/cannot-ignore-self
 import { AlreadyIgnoredException } from '../errors/external/already-ignored.exception';
 import { UserNotIgnoredException } from '../errors/external/user-not-ignored.exception';
 import { EventBusService } from './event-bus.service';
+import { EventNames } from '../events/event-names.enum';
 import { UserIgnoredEvent, UserUnignoredEvent } from '../events';
 
 export interface PaginationParams {
@@ -35,9 +36,12 @@ export class IgnoredUserService implements OnModuleInit {
     ) {}
 
     onModuleInit(): void {
-        // Listen for ignore requests from ContactRequestService
+        this.listenOnEvents();
+    }
+
+    private listenOnEvents() {
         this.eventBus.on<UserIgnoredEvent>(
-            'user.ignore-request',
+            EventNames.USER_IGNORE_REQUEST,
             async (payload: UserIgnoredEvent) => {
                 this.logger.debug(
                     `Handling ignore request: ${payload.userId} -> ${payload.ignoredUserId}`,
@@ -108,8 +112,7 @@ export class IgnoredUserService implements OnModuleInit {
 
         await this.removeContactFromUserEntity(user, ignoredUserId);
 
-        // Emit event for WebSocket broadcast
-        this.eventBus.emitAsync<UserIgnoredEvent>('user.ignored', {
+        this.eventBus.emitAsync<UserIgnoredEvent>(EventNames.USER_IGNORED, {
             userId,
             ignoredUserId,
         });
@@ -147,8 +150,7 @@ export class IgnoredUserService implements OnModuleInit {
             throw new UserNotIgnoredException();
         }
 
-        // Emit event for WebSocket broadcast
-        this.eventBus.emitAsync<UserUnignoredEvent>('user.unignored', {
+        this.eventBus.emitAsync<UserUnignoredEvent>(EventNames.USER_UNIGNORED, {
             userId,
             unignoredUserId: ignoredUserId,
         });

--- a/backend/src/services/message.service.spec.ts
+++ b/backend/src/services/message.service.spec.ts
@@ -8,18 +8,21 @@ import { Mocked } from '@suites/doubles.jest';
 import { getModelToken } from '@nestjs/mongoose';
 import { ContactGroupEntity } from '../schemas/contact-group.schema';
 import { MessageEntity } from '../schemas/message.schema';
-import { ContactService } from './contact.service';
-import { RealTimeChatGateway } from '../gateways/socket.gateway';
 import { Contact } from '../../shared/contact.contract';
 import { UserNotFoundException } from '../errors/internal/user-not-found.exception';
 import { ContactGroup } from '../../shared/contact-group.contract';
-import { ContactGroupService } from './contact-group.service';
+import { EventBusService } from './event-bus.service';
+import { EventNames } from '../events/event-names.enum';
+import { MessageSentEvent } from '../events/message.events';
+import {
+    ContactAutoAddEvent,
+    ContactGroupAutoAddEvent,
+} from '../events/contact.events';
 
 describe('MessageService', () => {
     let messageService: MessageService;
 
-    let contactService: Mocked<ContactService>;
-    let contactGroupService: Mocked<ContactGroupService>;
+    let eventBus: Mocked<EventBusService>;
     let contactGroupRepository: Mocked<Model<ContactGroupEntity>>;
     let messageRepository: Mocked<Model<MessageEntity>>;
     let userRepository: Mocked<Model<UserEntity>>;
@@ -33,8 +36,6 @@ describe('MessageService', () => {
     const receiverSaveMock = jest.fn();
 
     let testReceiverGroup: ContactGroup;
-
-    const gatewayEmitMock = jest.fn();
 
     beforeAll(async () => {
         const { unit, unitRef } = await TestBed.solitary(MessageService)
@@ -60,12 +61,6 @@ describe('MessageService', () => {
                     },
                 })),
             }))
-            .mock(RealTimeChatGateway)
-            .impl(() => ({
-                prepareSendMessage: () => ({
-                    emit: gatewayEmitMock,
-                }),
-            }))
             .mock(getModelToken(ContactGroupEntity.name))
             .impl((stubFn) => ({
                 findOne: stubFn().mockImplementation((query: any) => {
@@ -84,8 +79,7 @@ describe('MessageService', () => {
 
         messageService = unit;
 
-        contactService = unitRef.get(ContactService);
-        contactGroupService = unitRef.get(ContactGroupService);
+        eventBus = unitRef.get(EventBusService);
         contactGroupRepository = unitRef.get(
             getModelToken(ContactGroupEntity.name),
         );
@@ -134,7 +128,7 @@ describe('MessageService', () => {
                     memberName: testReceiver.username,
                 },
             ],
-            name: 'testGroup1',
+            name: 'testSender',
             _id: 'groupId1',
         };
 
@@ -191,12 +185,10 @@ describe('MessageService', () => {
             } satisfies Contact;
 
             messageRepository.create.mockResolvedValue(testMessage as any);
-            contactService.addContactIfNotExists.mockImplementationOnce(
-                async () => {
-                    testReceiver.contacts.push(newContact);
-                    return newContact;
-                },
-            );
+            eventBus.emitAsync.mockImplementationOnce(async () => {
+                testReceiver.contacts.push(newContact);
+                return newContact;
+            });
 
             const result = await messageService.sendMessage(
                 testMessage.fromUserId,
@@ -208,15 +200,18 @@ describe('MessageService', () => {
             expect(result).toEqual({ status: 201, body: testMessage });
             expect(userRepository.findById).toHaveBeenCalled();
             expect(messageRepository.create).toHaveBeenCalled();
-            expect(contactService.addContactIfNotExists).toHaveBeenCalled();
+            expect(eventBus.emitAsync).toHaveBeenCalled();
             expect(receiverMarkModifiedMock).toHaveBeenCalled();
             expect(receiverSaveMock).toHaveBeenCalled();
             expect(testSender.contacts[0].lastMessage).toEqual(testMessage._id);
             expect(testReceiver.contacts).toHaveLength(1);
-            expect(gatewayEmitMock).toHaveBeenCalledTimes(2);
-            expect(gatewayEmitMock).toHaveBeenCalledWith(
-                'contactAutoAdded',
-                newContact,
+            expect(eventBus.emitAsync).toHaveBeenCalledTimes(2);
+            expect(eventBus.emitAsync).toHaveBeenCalledWith(
+                EventNames.CONTACT_AUTO_ADD,
+                {
+                    userId: testMessage.toUserId,
+                    contactUserId: testMessage.fromUserId,
+                } satisfies ContactAutoAddEvent,
             );
         });
 
@@ -246,12 +241,10 @@ describe('MessageService', () => {
                 avatarFileName: testSender.avatarFileName,
                 isAccepted: false,
             };
-            contactService.addContactIfNotExists.mockImplementationOnce(
-                async () => {
-                    testReceiver.contacts.push(newContact);
-                    return newContact;
-                },
-            );
+            eventBus.emitAsync.mockImplementationOnce(async () => {
+                testReceiver.contacts.push(newContact);
+                return newContact;
+            });
 
             const result = await messageService.sendMessage(
                 testMessage.fromUserId,
@@ -269,14 +262,22 @@ describe('MessageService', () => {
             expect(testReceiver.contacts[0].lastMessage).toEqual(
                 testMessage._id,
             );
-            expect(gatewayEmitMock).toHaveBeenCalledTimes(2);
-            expect(gatewayEmitMock).toHaveBeenCalledWith(
-                'contactAutoAdded',
-                newContact,
+            expect(eventBus.emitAsync).toHaveBeenCalledTimes(2);
+            expect(eventBus.emitAsync).toHaveBeenNthCalledWith(
+                1,
+                EventNames.CONTACT_AUTO_ADD,
+                {
+                    userId: testMessage.toUserId,
+                    contactUserId: testMessage.fromUserId,
+                } satisfies ContactAutoAddEvent,
             );
-            expect(gatewayEmitMock).toHaveBeenCalledWith(
-                'message',
-                testMessage,
+            expect(eventBus.emitAsync).toHaveBeenNthCalledWith(
+                2,
+                EventNames.MESSAGE_SENT,
+                {
+                    message: testMessage,
+                    toUserId: testMessage.toUserId,
+                } satisfies MessageSentEvent,
             );
         });
 
@@ -295,10 +296,6 @@ describe('MessageService', () => {
 
             messageRepository.create.mockResolvedValue(testMessage as any);
 
-            contactGroupService.computeGroupNamesForUser.mockResolvedValue([
-                { ...testReceiverGroup, lastMessage: testMessage._id },
-            ]);
-
             const result = await messageService.sendMessage(
                 testMessage.fromUserId,
                 testMessage.toUserId,
@@ -315,17 +312,22 @@ describe('MessageService', () => {
             expect(receiverSaveMock).toHaveBeenCalledTimes(0);
             expect(testReceiverGroup.lastMessage).toEqual(testMessage._id);
 
-            expect(gatewayEmitMock).toHaveBeenCalledTimes(2);
-            expect(gatewayEmitMock).toHaveBeenCalledWith(
-                'contactGroupAutoAdded',
+            expect(eventBus.emitAsync).toHaveBeenCalledTimes(2);
+            expect(eventBus.emitAsync).toHaveBeenNthCalledWith(
+                1,
+                EventNames.CONTACT_GROUP_AUTO_ADD,
                 {
-                    ...testReceiverGroup,
-                    lastMessage: testMessage._id,
-                },
+                    userId: testReceiver._id,
+                    group: testReceiverGroup,
+                } satisfies ContactGroupAutoAddEvent,
             );
-            expect(gatewayEmitMock).toHaveBeenCalledWith(
-                'message',
-                testMessage,
+            expect(eventBus.emitAsync).toHaveBeenNthCalledWith(
+                2,
+                EventNames.MESSAGE_SENT,
+                {
+                    message: testMessage satisfies Message,
+                    toUserId: testReceiver._id,
+                } satisfies MessageSentEvent,
             );
         });
     });

--- a/backend/src/services/message.service.spec.ts
+++ b/backend/src/services/message.service.spec.ts
@@ -276,7 +276,7 @@ describe('MessageService', () => {
                 EventNames.MESSAGE_SENT,
                 {
                     message: testMessage,
-                    toUserId: testMessage.toUserId,
+                    recipientId: testMessage.toUserId,
                 } satisfies MessageSentEvent,
             );
         });
@@ -326,7 +326,7 @@ describe('MessageService', () => {
                 EventNames.MESSAGE_SENT,
                 {
                     message: testMessage satisfies Message,
-                    toUserId: testReceiver._id,
+                    recipientId: testReceiver._id,
                 } satisfies MessageSentEvent,
             );
         });

--- a/backend/src/services/message.service.ts
+++ b/backend/src/services/message.service.ts
@@ -21,12 +21,11 @@ import { IgnoredUserService } from './ignored-user.service';
 import { UserIsIgnoredException } from '../errors/external/user-is-ignored.exception';
 import { EventBusService } from './event-bus.service';
 import { EventNames } from '../events/event-names.enum';
+import { MessageReadEvent, MessageSentEvent } from '../events/message.events';
 import {
     ContactAutoAddEvent,
     ContactGroupAutoAddEvent,
-    MessageReadEvent,
-    MessageSentEvent,
-} from '../events';
+} from '../events/contact.events';
 
 @Injectable()
 export class MessageService {

--- a/backend/src/services/message.service.ts
+++ b/backend/src/services/message.service.ts
@@ -224,7 +224,6 @@ export class MessageService {
         const messageSentPayload: MessageSentEvent = {
             fromUserId,
             toUserId,
-            messageId: newlyCreatedMessage._id.toString(),
             message: newlyCreatedMessage,
             isGroup: !!contactGroup,
         };

--- a/backend/src/services/message.service.ts
+++ b/backend/src/services/message.service.ts
@@ -20,6 +20,7 @@ import { UserService } from './user.service';
 import { IgnoredUserService } from './ignored-user.service';
 import { UserIsIgnoredException } from '../errors/external/user-is-ignored.exception';
 import { EventBusService } from './event-bus.service';
+import { EventNames } from '../events/event-names.enum';
 import {
     ContactAutoAddEvent,
     ContactGroupAutoAddEvent,
@@ -96,10 +97,13 @@ export class MessageService {
                     { _id: message._id },
                     { read: true },
                 );
-                this.eventBus.emitAsync<MessageReadEvent>('message.read', {
-                    messageId: message._id.toString(),
-                    readerUserId: userId,
-                });
+                this.eventBus.emitAsync<MessageReadEvent>(
+                    EventNames.MESSAGE_READ,
+                    {
+                        messageId: message._id.toString(),
+                        readerUserId: userId,
+                    },
+                );
             }
         }
 
@@ -227,14 +231,15 @@ export class MessageService {
         };
 
         if (isNotContactGroup) {
-            // Emit contact auto-add event
-            this.eventBus.emitAsync<ContactAutoAddEvent>('contact.auto-add', {
-                userId: toUserId,
-                contactUserId: fromUserId,
-            });
-            // Emit message sent event for WebSocket broadcast
+            this.eventBus.emitAsync<ContactAutoAddEvent>(
+                EventNames.CONTACT_AUTO_ADD,
+                {
+                    userId: toUserId,
+                    contactUserId: fromUserId,
+                },
+            );
             this.eventBus.emitAsync<MessageSentEvent>(
-                'message.sent',
+                EventNames.MESSAGE_SENT,
                 messageSentPayload,
             );
         } else if (contactGroup) {
@@ -244,15 +249,14 @@ export class MessageService {
                 contactGroup,
             );
 
-            // Emit event for each group member
+            // Emit event for each group member except sender
             for (const memberRef of contactGroup.memberRefs) {
                 if (memberRef.memberId === fromUserId) {
                     continue;
                 }
 
-                // Emit contact group auto-add event
                 this.eventBus.emitAsync<ContactGroupAutoAddEvent>(
-                    'contact-group.auto-add',
+                    EventNames.CONTACT_GROUP_AUTO_ADD,
                     {
                         userId: memberRef.memberId,
                         group: {
@@ -268,11 +272,13 @@ export class MessageService {
                     },
                 );
 
-                // Emit message sent event for each member
-                this.eventBus.emitAsync<MessageSentEvent>('message.sent', {
-                    ...messageSentPayload,
-                    toUserId: memberRef.memberId,
-                });
+                this.eventBus.emitAsync<MessageSentEvent>(
+                    EventNames.MESSAGE_SENT,
+                    {
+                        ...messageSentPayload,
+                        toUserId: memberRef.memberId,
+                    },
+                );
             }
         } else {
             throw new ContactNotFoundException();
@@ -318,7 +324,7 @@ export class MessageService {
         msg.read = true;
         const updatedMsg = await msg.save();
 
-        this.eventBus.emitAsync<MessageReadEvent>('message.read', {
+        this.eventBus.emitAsync<MessageReadEvent>(EventNames.MESSAGE_READ, {
             messageId: updatedMsg._id.toString(),
             readerUserId: updatedMsg.toUserId.toString(),
         });

--- a/backend/src/services/message.service.ts
+++ b/backend/src/services/message.service.ts
@@ -3,26 +3,29 @@ import { InjectModel } from '@nestjs/mongoose';
 import { MessageEntity } from '../schemas/message.schema';
 import { HydratedDocument, Model } from 'mongoose';
 import { UserEntity } from '../schemas/user.schema';
-import { UserService } from './user.service';
 import { Message, MessageType } from '../../shared/message.contract';
-import { SocketMessageTypes } from '../../shared/socket-message-types.enum';
-import { RealTimeChatGateway } from '../gateways/socket.gateway';
 import { ObjectStorageService } from './object-storage.service';
 import { ContactGroupEntity } from '../schemas/contact-group.schema';
 import { MessageNotFoundException } from '../errors/internal/message-not-found.exception';
 import { UserNotFoundException } from '../errors/internal/user-not-found.exception';
-import { ContactService } from './contact.service';
 import {
     validateAndSanitizeAudioFile,
     validateAndSanitizeImageFile,
     ValidatedFile,
 } from '../utils/file-validation.util';
 import { FileAccessEntity } from '../schemas/file-access.schema';
-import { ContactGroupService } from './contact-group.service';
 import { ContactGroup } from '../../shared/contact-group.contract';
 import { ContactNotFoundException } from '../errors/internal/contact-not-found.exception';
+import { UserService } from './user.service';
 import { IgnoredUserService } from './ignored-user.service';
 import { UserIsIgnoredException } from '../errors/external/user-is-ignored.exception';
+import { EventBusService } from './event-bus.service';
+import {
+    MessageSentEvent,
+    MessageReadEvent,
+    ContactAutoAddEvent,
+    ContactGroupAutoAddEvent,
+} from '../events';
 
 @Injectable()
 export class MessageService {
@@ -31,18 +34,16 @@ export class MessageService {
     constructor(
         @InjectModel(ContactGroupEntity.name)
         private readonly contactGroupModel: Model<ContactGroupEntity>,
-        private readonly contactGroupService: ContactGroupService,
-        private readonly contactService: ContactService,
         @InjectModel(FileAccessEntity.name)
         private readonly fileAccessModel: Model<FileAccessEntity>,
-        private readonly gateway: RealTimeChatGateway,
         @InjectModel(MessageEntity.name)
         private readonly messageModel: Model<MessageEntity>,
-        private readonly objectStorageService: ObjectStorageService,
         @InjectModel(UserEntity.name)
         private readonly userModel: Model<UserEntity>,
+        private readonly objectStorageService: ObjectStorageService,
         private readonly userService: UserService,
         private readonly ignoredUserService: IgnoredUserService,
+        private readonly eventBus: EventBusService,
     ) {}
 
     async getMessageById(messageId: string) {
@@ -95,9 +96,10 @@ export class MessageService {
                     { _id: message._id },
                     { read: true },
                 );
-                this.gateway
-                    .prepareSendMessage(message.fromUserId)
-                    ?.emit(SocketMessageTypes.messageRead, message._id);
+                this.eventBus.emitAsync<MessageReadEvent>('message.read', {
+                    messageId: message._id.toString(),
+                    readerUserId: userId,
+                });
             }
         }
 
@@ -216,10 +218,28 @@ export class MessageService {
 
         const newlyCreatedMessage = await this.messageModel.create(newMessage);
 
-        if (isNotContactGroup) {
-            await this.autoAddSenderToReceiverContacts(fromUserId, toUserId);
+        const messageSentPayload: MessageSentEvent = {
+            fromUserId,
+            toUserId,
+            messageId: newlyCreatedMessage._id.toString(),
+            message: newlyCreatedMessage,
+            isGroup: !!contactGroup,
+        };
 
-            this.emitMessageViaWebSocket(toUserId, newlyCreatedMessage);
+        if (isNotContactGroup) {
+            // Emit contact auto-add event
+            this.eventBus.emitAsync<ContactAutoAddEvent>(
+                'contact.auto-add',
+                {
+                    userId: toUserId,
+                    contactUserId: fromUserId,
+                },
+            );
+            // Emit message sent event for WebSocket broadcast
+            this.eventBus.emitAsync<MessageSentEvent>(
+                'message.sent',
+                messageSentPayload,
+            );
         } else if (contactGroup) {
             contactGroup.lastMessage = newlyCreatedMessage._id;
             await this.contactGroupModel.updateOne(
@@ -227,21 +247,33 @@ export class MessageService {
                 contactGroup,
             );
 
-            // Send to all members except the sender
+            // Emit event for each group member
             for (const memberRef of contactGroup.memberRefs) {
                 if (memberRef.memberId === fromUserId) {
                     continue;
                 }
 
-                await this.autoAddSenderGroupToReceiverContactGroups(
-                    contactGroup,
-                    memberRef.memberId,
+                // Emit contact group auto-add event
+                this.eventBus.emitAsync<ContactGroupAutoAddEvent>(
+                    'contact-group.auto-add',
+                    {
+                        userId: memberRef.memberId,
+                        group: {
+                            ...contactGroup.toObject(),
+                            _id: contactGroup._id.toString(),
+                            name: contactGroup.memberRefs
+                                .filter((m) => m.memberId !== memberRef.memberId)
+                                .map((m) => m.memberName)
+                                .join(', '),
+                        } as ContactGroup,
+                    },
                 );
 
-                this.emitMessageViaWebSocket(
-                    memberRef.memberId,
-                    newlyCreatedMessage,
-                );
+                // Emit message sent event for each member
+                this.eventBus.emitAsync<MessageSentEvent>('message.sent', {
+                    ...messageSentPayload,
+                    toUserId: memberRef.memberId,
+                });
             }
         } else {
             throw new ContactNotFoundException();
@@ -287,9 +319,10 @@ export class MessageService {
         msg.read = true;
         const updatedMsg = await msg.save();
 
-        this.gateway
-            .prepareSendMessage(updatedMsg.fromUserId)
-            ?.emit(SocketMessageTypes.messageRead, updatedMsg._id);
+        this.eventBus.emitAsync<MessageReadEvent>('message.read', {
+            messageId: updatedMsg._id.toString(),
+            readerUserId: updatedMsg.toUserId.toString(),
+        });
 
         return { status: 200 as const, body: true };
     }
@@ -336,58 +369,5 @@ export class MessageService {
         contactGroupId: string,
     ): Promise<ContactGroupEntity | null> {
         return this.contactGroupModel.findOne({ _id: contactGroupId }).lean();
-    }
-
-    private emitMessageViaWebSocket(
-        userSocketId: string,
-        messageToSend: Message,
-    ) {
-        this.gateway
-            .prepareSendMessage(userSocketId)
-            ?.emit(SocketMessageTypes.message, messageToSend);
-    }
-
-    private async autoAddSenderToReceiverContacts(
-        senderId: string,
-        receiverId: string,
-    ): Promise<void> {
-        try {
-            const newContact = await this.contactService.addContactIfNotExists(
-                receiverId,
-                senderId,
-            );
-
-            if (newContact) {
-                this.gateway
-                    .prepareSendMessage(receiverId)
-                    ?.emit(SocketMessageTypes.contactAutoAdded, newContact);
-            }
-        } catch (error) {
-            this.logger.error(
-                `Failed to auto-add sender ${senderId} to receiver ${receiverId}'s contacts: ${error}`,
-            );
-        }
-    }
-
-    private async autoAddSenderGroupToReceiverContactGroups(
-        senderGroup: ContactGroup,
-        receiverId: string,
-    ): Promise<void> {
-        try {
-            senderGroup = (
-                await this.contactGroupService.computeGroupNamesForUser(
-                    [senderGroup],
-                    receiverId,
-                )
-            )[0];
-
-            this.gateway
-                .prepareSendMessage(receiverId)
-                ?.emit(SocketMessageTypes.contactGroupAutoAdded, senderGroup);
-        } catch (error) {
-            this.logger.error(
-                `Failed to auto-add sender group ${senderGroup._id} to receiver ${receiverId}'s contact groups: ${error}`,
-            );
-        }
     }
 }

--- a/backend/src/services/message.service.ts
+++ b/backend/src/services/message.service.ts
@@ -100,7 +100,7 @@ export class MessageService {
                     EventNames.MESSAGE_READ,
                     {
                         messageId: message._id.toString(),
-                        readerUserId: userId,
+                        messageAuthorId: userId,
                     },
                 );
             }
@@ -317,7 +317,7 @@ export class MessageService {
 
         this.eventBus.emitAsync<MessageReadEvent>(EventNames.MESSAGE_READ, {
             messageId: updatedMsg._id.toString(),
-            readerUserId: updatedMsg.toUserId.toString(),
+            messageAuthorId: updatedMsg.fromUserId.toString(),
         });
 
         return { status: 200 as const, body: true };

--- a/backend/src/services/message.service.ts
+++ b/backend/src/services/message.service.ts
@@ -231,7 +231,7 @@ export class MessageService {
             );
             this.eventBus.emitAsync<MessageSentEvent>(EventNames.MESSAGE_SENT, {
                 message: newlyCreatedMessage,
-                toUserId,
+                recipientId: toUserId,
             });
         } else if (contactGroup) {
             contactGroup.lastMessage = newlyCreatedMessage._id;
@@ -267,7 +267,7 @@ export class MessageService {
                     EventNames.MESSAGE_SENT,
                     {
                         message: newlyCreatedMessage,
-                        toUserId: memberRef.memberId,
+                        recipientId: memberRef.memberId,
                     },
                 );
             }

--- a/backend/src/services/message.service.ts
+++ b/backend/src/services/message.service.ts
@@ -221,13 +221,6 @@ export class MessageService {
 
         const newlyCreatedMessage = await this.messageModel.create(newMessage);
 
-        const messageSentPayload: MessageSentEvent = {
-            fromUserId,
-            toUserId,
-            message: newlyCreatedMessage,
-            isGroup: !!contactGroup,
-        };
-
         if (isNotContactGroup) {
             this.eventBus.emitAsync<ContactAutoAddEvent>(
                 EventNames.CONTACT_AUTO_ADD,
@@ -236,10 +229,10 @@ export class MessageService {
                     contactUserId: fromUserId,
                 },
             );
-            this.eventBus.emitAsync<MessageSentEvent>(
-                EventNames.MESSAGE_SENT,
-                messageSentPayload,
-            );
+            this.eventBus.emitAsync<MessageSentEvent>(EventNames.MESSAGE_SENT, {
+                message: newlyCreatedMessage,
+                toUserId,
+            });
         } else if (contactGroup) {
             contactGroup.lastMessage = newlyCreatedMessage._id;
             await this.contactGroupModel.updateOne(
@@ -273,7 +266,7 @@ export class MessageService {
                 this.eventBus.emitAsync<MessageSentEvent>(
                     EventNames.MESSAGE_SENT,
                     {
-                        ...messageSentPayload,
+                        message: newlyCreatedMessage,
                         toUserId: memberRef.memberId,
                     },
                 );

--- a/backend/src/services/message.service.ts
+++ b/backend/src/services/message.service.ts
@@ -21,10 +21,10 @@ import { IgnoredUserService } from './ignored-user.service';
 import { UserIsIgnoredException } from '../errors/external/user-is-ignored.exception';
 import { EventBusService } from './event-bus.service';
 import {
-    MessageSentEvent,
-    MessageReadEvent,
     ContactAutoAddEvent,
     ContactGroupAutoAddEvent,
+    MessageReadEvent,
+    MessageSentEvent,
 } from '../events';
 
 @Injectable()
@@ -228,13 +228,10 @@ export class MessageService {
 
         if (isNotContactGroup) {
             // Emit contact auto-add event
-            this.eventBus.emitAsync<ContactAutoAddEvent>(
-                'contact.auto-add',
-                {
-                    userId: toUserId,
-                    contactUserId: fromUserId,
-                },
-            );
+            this.eventBus.emitAsync<ContactAutoAddEvent>('contact.auto-add', {
+                userId: toUserId,
+                contactUserId: fromUserId,
+            });
             // Emit message sent event for WebSocket broadcast
             this.eventBus.emitAsync<MessageSentEvent>(
                 'message.sent',
@@ -259,10 +256,12 @@ export class MessageService {
                     {
                         userId: memberRef.memberId,
                         group: {
-                            ...contactGroup.toObject(),
+                            ...contactGroup,
                             _id: contactGroup._id.toString(),
                             name: contactGroup.memberRefs
-                                .filter((m) => m.memberId !== memberRef.memberId)
+                                .filter(
+                                    (m) => m.memberId !== memberRef.memberId,
+                                )
                                 .map((m) => m.memberName)
                                 .join(', '),
                         } as ContactGroup,

--- a/frontend/src/dashboard/chat/top-bar/TopBar.tsx
+++ b/frontend/src/dashboard/chat/top-bar/TopBar.tsx
@@ -122,7 +122,7 @@ export function TopBar(props: { selectedContact: Contact | ContactGroup }) {
                             {LL.LEAVE_GROUP()}
                         </MenuItem>
                     ) : (
-                        <>
+                        <span>
                             <MenuItem
                                 onClick={() =>
                                     deleteChat(selectedContact, handleClose)
@@ -140,7 +140,7 @@ export function TopBar(props: { selectedContact: Contact | ContactGroup }) {
                                     {LL.IGNORE()}
                                 </MenuItem>
                             )}
-                        </>
+                        </span>
                     )}
                 </Menu>
             </div>

--- a/helm/realtime-chat/Chart.yaml
+++ b/helm/realtime-chat/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.16
+version: 0.2.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.9.7"
+appVersion: "1.9.8"

--- a/helm/realtime-chat/values.yaml
+++ b/helm/realtime-chat/values.yaml
@@ -11,7 +11,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.9.7"
+  tag: "1.9.8"
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "real-time-chat-app",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "real-time-chat-app",
-      "version": "1.9.7",
+      "version": "1.9.8",
       "license": "ISC",
       "workspaces": [
         "backend",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@nestjs/common": "^11.1.12",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.12",
+        "@nestjs/event-emitter": "^3.1.0",
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/mongoose": "^11.0.4",
         "@nestjs/platform-express": "^11.1.12",
@@ -4728,6 +4729,25 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@nestjs/event-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/event-emitter/-/event-emitter-3.1.0.tgz",
+      "integrity": "sha512-DOY/4XBGyIjYyOJKkO6jl1kzFE0ZfX0wV+M2HR5NWymPT9Z0zdCEcZGxTXXkoMRwPtglnvCGJALSjOpXPIcM3g==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter2": "6.4.9"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/event-emitter/node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
+      "license": "MIT"
     },
     "node_modules/@nestjs/jwt": {
       "version": "11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "real-time-chat-app",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/specs/2026-06-05_decouple-with-events/plan.md
+++ b/specs/2026-06-05_decouple-with-events/plan.md
@@ -1,0 +1,74 @@
+# Decouple Services with Event Bus - Plan
+
+## Overview
+Reduce tight coupling between backend services by introducing an event-driven architecture using NestJS EventEmitter2. This allows services to communicate asynchronously without direct dependencies.
+
+## Phases
+
+### Phase 1: Foundation (Est: 1-2 hours)
+- [ ] Create `EventBusService` wrapper around `@nestjs/event-emitter`
+- [ ] Define event types and payload interfaces in `events/` directory
+- [ ] Add `EventEmitterModule.forRoot()` to app module
+
+### Phase 2: MessageService Refactoring (Est: 2-3 hours)
+- [ ] Replace direct `ContactService.addContactIfNotExists()` calls with events
+- [ ] Replace direct `RealTimeChatGateway` calls with events
+- [ ] Replace direct `IgnoredUserService.isUserIgnored()` checks (keep for now - validation required)
+- [ ] Remove `ContactService`, `ContactGroupService`, `IgnoredUserService` from MessageService constructor
+
+### Phase 3: Listener Services (Est: 2-3 hours)
+- [ ] Create event listeners in `ContactService` for auto-add contact logic
+- [ ] Create event listeners in `IgnoredUserService` for ignore/unignore notifications
+- [ ] Create event listeners in `RealTimeChatGateway` for message/read events
+
+### Phase 4: ContactRequestService (Est: 1-2 hours)
+- [ ] Replace direct `IgnoredUserService.ignoreUser()` with event emission
+- [ ] Remove `IgnoredUserService` dependency
+
+### Phase 5: IgnoredUserService (Est: 1 hour)
+- [ ] Remove `RealTimeChatGateway` dependency
+- [ ] Emit events instead of direct gateway calls
+
+### Phase 6: Cleanup (Est: 1 hour)
+- [ ] Remove `forwardRef` usages
+- [ ] Update all service tests to work with new structure
+- [ ] Remove unused imports
+
+## File Changes Summary
+
+| File | Action | Dependencies Removed | Dependencies Added |
+|------|--------|----------------------|-------------------|
+| `event-bus.service.ts` | CREATE | - | EventEmitter2 |
+| `events/` | CREATE | - | - |
+| `message.service.ts` | MODIFY | ContactService, ContactGroupService, IgnoredUserService, UserService | EventBusService |
+| `contact.service.ts` | MODIFY | - | EventBusService |
+| `ignored-user.service.ts` | MODIFY | RealTimeChatGateway | EventBusService |
+| `contact-request.service.ts` | MODIFY | IgnoredUserService | EventBusService |
+| `app.module.ts` | MODIFY | - | EventEmitterModule |
+
+## Risk Assessment
+
+### Low Risk
+- EventBusService creation
+- Adding EventEmitterModule to app
+- Defining event types
+
+### Medium Risk
+- Removing direct service calls from MessageService
+- Need to ensure event listeners are properly registered
+
+### Mitigation
+- Implement one event flow at a time
+- Run tests after each phase
+- Keep old direct calls commented out until new flow verified
+
+## Rollback Strategy
+- All changes are additive initially (new files, new methods)
+- Direct service calls can be restored by reverting individual commits
+- Feature flags possible for gradual rollout
+
+## Success Criteria
+- MessageService constructor has ≤3 dependencies (from 7)
+- No `forwardRef` usage in services
+- All existing tests pass
+- No breaking changes to API contracts

--- a/specs/2026-06-05_decouple-with-events/requirements.md
+++ b/specs/2026-06-05_decouple-with-events/requirements.md
@@ -1,0 +1,97 @@
+# Decouple Services with Event Bus - Requirements
+
+## Must Have
+
+### Functional Requirements
+- [ ] Services must emit events for cross-cutting concerns (message sent, user ignored, etc.)
+- [ ] Event listeners must handle the same logic currently done via direct service calls
+- [ ] All existing API endpoints must continue to work with identical responses
+- [ ] All existing WebSocket events must continue to be emitted
+- [ ] Error handling must maintain same behavior (exceptions, logging)
+
+### Non-Functional Requirements
+- [ ] No breaking changes to public service APIs
+- [ ] No performance degradation (events should not add >10ms latency)
+- [ ] Memory footprint increase <5MB
+- [ ] All existing unit tests must pass without modification to test code
+
+### Technical Requirements
+- [ ] Use `@nestjs/event-emitter` package (already in project or add v2.x)
+- [ ] Event payloads must be typed with TypeScript interfaces
+- [ ] Event names must follow pattern: `<entity>.<action>` (e.g., `message.sent`, `user.ignored`)
+- [ ] Events must be async (non-blocking)
+- [ ] No circular dependencies introduced
+- [ ] Services must not directly inject other services for cross-cutting concerns
+
+### Event Definitions
+
+#### Message Events
+```typescript
+interface MessageSentEvent {
+    fromUserId: string;
+    toUserId: string;
+    messageId: string;
+    message: Message;
+    isGroup: boolean;
+}
+
+interface MessageReadEvent {
+    messageId: string;
+    readerUserId: string;
+}
+```
+
+#### Contact Events
+```typescript
+interface ContactAutoAddEvent {
+    userId: string;        // User to add contact to
+    contactUserId: string; // Contact to add
+}
+
+interface ContactGroupAutoAddEvent {
+    userId: string;
+    group: ContactGroup;
+}
+```
+
+#### User Events
+```typescript
+interface UserIgnoredEvent {
+    userId: string;        // User who did the ignoring
+    ignoredUserId: string;
+}
+
+interface UserUnignoredEvent {
+    userId: string;
+    unignoredUserId: string;
+}
+```
+
+## Must Not Have
+
+### Anti-Requirements
+- [ ] Do NOT change the database schema
+- [ ] Do NOT change the WebSocket API (event types, payloads)
+- [ ] Do NOT change the REST API (routes, request/response formats)
+- [ ] Do NOT remove existing direct method calls within the same service (only cross-service calls)
+- [ ] Do NOT introduce new external dependencies beyond `@nestjs/event-emitter`
+- [ ] Do NOT use a message queue (RabbitMQ, Kafka) - keep it in-memory for now
+
+## Constraints
+- NestJS v10.x compatible
+- Must work with existing Mongoose models
+- Must work with existing Socket.IO gateway
+- Must maintain existing logging format and levels
+- Must maintain existing error types and exception handling
+
+## Dependencies
+- `@nestjs/event-emitter` >= 2.0.0
+- Existing NestJS common, core packages
+
+## Out of Scope
+- Repository pattern implementation
+- Domain-driven design refactoring
+- Moving to CQRS pattern
+- Introducing external message brokers
+- Changing authentication/authorization logic
+- Refactoring frontend code

--- a/specs/2026-06-05_decouple-with-events/validation.md
+++ b/specs/2026-06-05_decouple-with-events/validation.md
@@ -1,0 +1,184 @@
+# Decouple Services with Event Bus - Validation
+
+## Validation Strategy
+
+### 1. Unit Test Validation
+
+#### MessageService Tests
+```bash
+# Run existing tests - must all pass
+npm run test -- message.service.spec.ts
+```
+
+**Test Coverage to Verify:**
+- [ ] `sendMessage()` still works correctly
+- [ ] Auto-add contact still happens when message sent to non-contact
+- [ ] Auto-add group still happens when message sent to group
+- [ ] Ignored user check still prevents message sending
+- [ ] Message read events still emitted via WebSocket
+- [ ] `deleteMessages()` still works
+- [ ] `uploadFileAsMessage()` still works
+
+#### ContactService Tests
+```bash
+npm run test -- contact.service.spec.ts
+```
+
+**Test Coverage:**
+- [ ] `addContactIfNotExists()` still called via event listener
+- [ ] Online status checking still works
+- [ ] Ignored user check still works
+
+#### IgnoredUserService Tests
+```bash
+npm run test -- ignored-user.service.spec.ts
+```
+
+**Test Coverage:**
+- [ ] `ignoreUser()` still works
+- [ ] `unignoreUser()` still works
+- [ ] WebSocket events still emitted
+- [ ] Contact removal still happens
+
+### 2. Integration Test Validation
+
+#### Manual API Tests
+
+**POST /api/messages/send**
+```bash
+curl -X POST http://localhost:3000/api/messages/send \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"toUserId": "<user2-id>", "message": "test", "type": "text"}'
+```
+
+**Verify:**
+- [ ] Response: 201 with message data
+- [ ] User2 receives message via WebSocket
+- [ ] If user2 not in contacts, they are auto-added
+- [ ] If user1 ignored user2, returns 403
+
+**POST /api/users/ignore**
+```bash
+curl -X POST http://localhost:3000/api/users/ignore/<user2-id> \
+  -H "Authorization: Bearer <token>"
+```
+
+**Verify:**
+- [ ] Response: 201
+- [ ] User2 removed from contacts
+- [ ] User receives `userIgnored` WebSocket event
+- [ ] Cannot send message to ignored user
+
+### 3. Dependency Validation
+
+#### Before Refactoring
+```bash
+# Check current dependency count
+grep -n "constructor" src/services/message.service.ts | head -1
+# Expected: 7+ constructor parameters
+```
+
+#### After Refactoring
+```bash
+# Check reduced dependency count
+grep -n "constructor" src/services/message.service.ts | head -1
+# Expected: 2-3 constructor parameters
+```
+
+**Dependency Count Targets:**
+| Service | Current | Target | Status |
+|---------|---------|--------|--------|
+| MessageService | 7 | ≤3 | [ ] |
+| ContactService | 4 | ≤3 | [ ] |
+| IgnoredUserService | 3 | ≤2 | [ ] |
+| ContactRequestService | 2 | ≤2 | [ ] |
+
+### 4. Circular Dependency Validation
+
+```bash
+# Check for forwardRef usage - should be 0
+rg "forwardRef" src/services/ | wc -l
+# Expected: 0
+```
+
+### 5. Event Flow Validation
+
+**Test Event Flow:**
+```typescript
+// In a test or manually verify:
+// 1. MessageService emits message.sent
+// 2. ContactService listener receives it
+// 3. ContactService auto-adds contact
+// 4. RealTimeChatGateway listener receives it
+// 5. Gateway emits message to receiver
+```
+
+**Verification Queries:**
+```bash
+# Check event bus is being used
+rg "eventBus.emit" src/services/
+rg "eventBus.on\|@OnEvent" src/services/
+```
+
+### 6. Performance Validation
+
+**Before:**
+```bash
+# Measure sendMessage endpoint response time
+# Run 100 requests, measure avg response time
+```
+
+**After:**
+```bash
+# Same measurement
+# Expected: <10ms increase in average response time
+```
+
+### 7. Build Validation
+
+```bash
+# Build must succeed
+npm run build
+
+# Lint must pass
+npm run lint
+
+# Type check must pass
+npm run type-check
+```
+
+## Acceptance Criteria Checklist
+
+- [ ] All existing unit tests pass
+- [ ] All existing integration tests pass
+- [ ] Manual API tests pass
+- [ ] No circular dependencies (no `forwardRef`)
+- [ ] MessageService has ≤3 constructor dependencies
+- [ ] IgnoredUserService has ≤2 constructor dependencies
+- [ ] Build, lint, and type-check all pass
+- [ ] No breaking changes to API
+- [ ] No new external dependencies beyond `@nestjs/event-emitter`
+
+## Validation Commands
+
+```bash
+# Run all validation
+npm run test && npm run build && npm run lint
+
+# Check circular deps
+npx madge --circular src/services/
+
+# Check dependency injection graph
+npx @nestjs/schematics:dependencies-tree
+```
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Service dependency reduction | 50% | Count constructor params |
+| Circular dependencies | 0 | `madge --circular` |
+| Test coverage | 100% | Existing test suite |
+| Performance impact | <10ms | Load testing |
+| Build time impact | <5s | `time npm run build` |


### PR DESCRIPTION
Decreases coupling between services and gets rid of a `forwardRef()` call which was needed because of a cyclic dependency.